### PR TITLE
Feature/fix cancel exception

### DIFF
--- a/src/Downloader/DownloadService.cs
+++ b/src/Downloader/DownloadService.cs
@@ -57,7 +57,14 @@ namespace Downloader
             if (File.Exists(Package.FileName))
                 File.Delete(Package.FileName);
 
-            await StartDownload();
+            try
+            {
+                await StartDownload();
+            }
+            catch (OperationCanceledException)
+            {
+                OnDownloadFileCompleted(new AsyncCompletedEventArgs(null, true, Package));
+            }
         }
         public async Task DownloadFileAsync(string address, string fileName)
         {
@@ -82,7 +89,14 @@ namespace Downloader
             if (File.Exists(Package.FileName))
                 File.Delete(Package.FileName);
 
-            await StartDownload();
+            try
+            {
+                await StartDownload();
+            }
+            catch (OperationCanceledException)
+            {
+                OnDownloadFileCompleted(new AsyncCompletedEventArgs(null, true, Package));
+            }
         }
         public void CancelAsync()
         {

--- a/src/Downloader/DownloadService.cs
+++ b/src/Downloader/DownloadService.cs
@@ -57,15 +57,9 @@ namespace Downloader
             if (File.Exists(Package.FileName))
                 File.Delete(Package.FileName);
 
-            try
-            {
-                await StartDownload();
-            }
-            catch (OperationCanceledException)
-            {
-                OnDownloadFileCompleted(new AsyncCompletedEventArgs(null, true, Package));
-            }
+            await StartDownload();
         }
+
         public async Task DownloadFileAsync(string address, string fileName)
         {
             IsBusy = true;
@@ -89,15 +83,9 @@ namespace Downloader
             if (File.Exists(Package.FileName))
                 File.Delete(Package.FileName);
 
-            try
-            {
-                await StartDownload();
-            }
-            catch (OperationCanceledException)
-            {
-                OnDownloadFileCompleted(new AsyncCompletedEventArgs(null, true, Package));
-            }
+            await StartDownload();
         }
+
         public void CancelAsync()
         {
             Cts?.Cancel(false);
@@ -205,6 +193,10 @@ namespace Downloader
                 await MergeChunks(Package.Chunks);
 
                 OnDownloadFileCompleted(new AsyncCompletedEventArgs(null, false, Package));
+            }
+            catch (OperationCanceledException)
+            {
+                OnDownloadFileCompleted(new AsyncCompletedEventArgs(null, true, Package));
             }
             finally
             {

--- a/src/Downloader/DownloadService.cs
+++ b/src/Downloader/DownloadService.cs
@@ -59,7 +59,6 @@ namespace Downloader
 
             await StartDownload();
         }
-
         public async Task DownloadFileAsync(string address, string fileName)
         {
             IsBusy = true;
@@ -85,7 +84,6 @@ namespace Downloader
 
             await StartDownload();
         }
-
         public void CancelAsync()
         {
             Cts?.Cancel(false);


### PR DESCRIPTION
Something to do with how I'm wrapping up `DownloadFileAsync` is causing it to throw an `OperactionCanceledException` when I cancel, I've tried to recreate it using tests but have been unable to.

Simply adding a catch for `OperactionCanceledException` to `StartDownload` solves the problem, I wish I was able to reproduce it though.

There's how I'm using it `DownloadFileAsync`:

`var download = Observable
                .FromAsync(
                    () => this.downloaders[id].DownloadFileAsync(url.AbsoluteUri,   destination.LocalPath)
                );`

