### PR TITLE
Feature/handle bad url

### DIFF
--- a/src/Downloader/DownloadService.cs
+++ b/src/Downloader/DownloadService.cs
@@ -61,28 +61,40 @@ namespace Downloader
         }
         public async Task DownloadFileAsync(string address, string fileName)
         {
-            IsBusy = true;
-            Cts = new CancellationTokenSource();
-            Package.FileName = fileName;
-            Package.Address = new Uri(address);
-            Package.TotalFileSize = GetFileSize(Package.Address);
-            Package.Options.Validate();
+            try
+            {
+                IsBusy = true;
+                Cts = new CancellationTokenSource();
+                Package.FileName = fileName;
+                Package.Address = new Uri(address);
+                Package.TotalFileSize = GetFileSize(Package.Address);
+                Package.Options.Validate();
 
-            if (Package.TotalFileSize <= 0)
-                throw new InvalidDataException("File size is invalid!");
+                if (Package.TotalFileSize <= 0)
+                    throw new InvalidDataException("File size is invalid!");
 
-            var neededParts =
-                (int)Math.Ceiling((double)Package.TotalFileSize / int.MaxValue); // for files as larger than 2GB
+                var neededParts =
+                    (int) Math.Ceiling(
+                        (double) Package.TotalFileSize / int.MaxValue
+                    ); // for files as larger than 2GB
 
-            // Handle number of parallel downloads  
-            var parts = Package.Options.ChunkCount < neededParts ? neededParts : Package.Options.ChunkCount;
+                // Handle number of parallel downloads  
+                var parts = Package.Options.ChunkCount < neededParts
+                    ? neededParts
+                    : Package.Options.ChunkCount;
 
-            Package.Chunks = ChunkFile(Package.TotalFileSize, parts);
+                Package.Chunks = ChunkFile(Package.TotalFileSize, parts);
 
-            if (File.Exists(Package.FileName))
-                File.Delete(Package.FileName);
+                if (File.Exists(Package.FileName))
+                    File.Delete(Package.FileName);
 
-            await StartDownload();
+                await StartDownload();
+            }
+            catch (Exception e)
+            {
+                OnDownloadFileCompleted(new AsyncCompletedEventArgs(e, false, Package));
+                throw;
+            }
         }
         public void CancelAsync()
         {
@@ -190,14 +202,11 @@ namespace Downloader
                 // Merge data to single file
                 await MergeChunks(Package.Chunks);
 
-                OnDownloadFileCompleted(new AsyncCompletedEventArgs(null, false, Package));
-            }
-            catch (OperationCanceledException)
-            {
-                OnDownloadFileCompleted(new AsyncCompletedEventArgs(null, true, Package));
             }
             finally
             {
+                OnDownloadFileCompleted(new AsyncCompletedEventArgs(null, false, Package));
+
                 if (Cts.Token.IsCancellationRequested == false)
                 {
                     // remove temp files
@@ -346,7 +355,7 @@ namespace Downloader
         }
         protected void RemoveTemps()
         {
-            if (RemoveTempsAfterDownloadCompleted)
+            if (RemoveTempsAfterDownloadCompleted && Package.Chunks != null)
             {
                 foreach (var chunk in Package.Chunks)
                 {

--- a/src/Downloader/DownloadService.cs
+++ b/src/Downloader/DownloadService.cs
@@ -202,6 +202,7 @@ namespace Downloader
                 // Merge data to single file
                 await MergeChunks(Package.Chunks);
 
+                OnDownloadFileCompleted(new AsyncCompletedEventArgs(null, false, Package));
             }
             catch (OperationCanceledException e)
             {

--- a/src/Downloader/DownloadService.cs
+++ b/src/Downloader/DownloadService.cs
@@ -203,10 +203,12 @@ namespace Downloader
                 await MergeChunks(Package.Chunks);
 
             }
+            catch (OperationCanceledException e)
+            {
+                OnDownloadFileCompleted(new AsyncCompletedEventArgs(e, true, Package));
+            }
             finally
             {
-                OnDownloadFileCompleted(new AsyncCompletedEventArgs(null, false, Package));
-
                 if (Cts.Token.IsCancellationRequested == false)
                 {
                     // remove temp files


### PR DESCRIPTION
When calling with a URL that doesnt exist GetFileSize throws and isn't handled, this means that the `DownloadFileCompleted` event never fires so it's left being perpetually busy. To resolve this I catch and rethrow exceptions in `DownloadFileAsync` after calling `OnDownloadFileCompleted()` with the exception.