### PR TITLE
Don't create a FileStream every time it writes bytes to improve perfo…

### DIFF
--- a/src/Downloader/FileStorage.cs
+++ b/src/Downloader/FileStorage.cs
@@ -7,10 +7,12 @@ namespace Downloader
     public class FileStorage : IStorage, IDisposable
     {
         private readonly string _fileName;
+        private readonly FileStream _writer;
 
         public FileStorage(string directory, string fileExtension = "")
         {
             _fileName = FileHelper.GetTempFile(directory, fileExtension);
+            _writer = new FileStream(_fileName, FileMode.Append, FileAccess.Write, FileShare.Delete | FileShare.ReadWrite);
         }
 
         public Stream OpenRead()
@@ -20,12 +22,13 @@ namespace Downloader
 
         public async Task WriteAsync(byte[] data, int offset, int count)
         {
-            using var writer = new FileStream(_fileName, FileMode.Append, FileAccess.Write, FileShare.Delete | FileShare.ReadWrite);
-            await writer.WriteAsync(data, offset, count);
+            await _writer.WriteAsync(data, offset, count);
         }
 
         public void Clear()
         {
+            _writer.Close();
+            
             if (File.Exists(_fileName))
             {
                 File.Delete(_fileName);


### PR DESCRIPTION
When I set `OnTheFlyDownload` to true download speeds are conciderable slower than in memory, which is understandable, but the difference is significant.

I'm using the sample app from the repo, set the `MaximumBytesPerSecond` to 0, `BufferBlockSize` to 16k and `ChunkCount` to 16.

I'm using this file: https://speed.hetzner.de/1GB.bin.

When running in Release with `OnTheFlyDownload` to `false` I'm getting an avg speed of 13MB/s, but when running with `OnTheFlyDownload` to `true` I'm getting an avg speed of only 23MB/s, but memory usage is through the roof of course.

This can remedied to not create a new `FileStream` every time it writes in `FileStorage`. 