### PR TITLE
Serialize FileStorage: FileName getter

### DIFF
--- a/src/Downloader/FileStorage.cs
+++ b/src/Downloader/FileStorage.cs
@@ -6,12 +6,19 @@ namespace Downloader
 {
     public class FileStorage : IStorage, IDisposable
     {
-        private readonly string _fileName;
+        public string FileName { get; }
         private FileStream _stream;
+
+        public FileStorage(string fileName)
+        {
+            var info = new FileInfo(fileName);
+            if (info.Exists) FileName = fileName;
+            else FileHelper.GetTempFile(info.DirectoryName, info.Extension);
+        }
 
         public FileStorage(string directory, string fileExtension = "")
         {
-            _fileName = FileHelper.GetTempFile(directory, fileExtension);
+            FileName = FileHelper.GetTempFile(directory, fileExtension);
         }
 
         public Stream OpenRead()
@@ -21,14 +28,16 @@ namespace Downloader
                 _stream.Flush();
                 _stream.Dispose();
             }
-            return new FileStream(_fileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Delete | FileShare.ReadWrite);
+
+            return new FileStream(FileName, FileMode.OpenOrCreate, FileAccess.ReadWrite,
+                FileShare.Delete | FileShare.ReadWrite);
         }
 
         public async Task WriteAsync(byte[] data, int offset, int count)
         {
             if (_stream?.CanWrite != true)
             {
-                _stream = new FileStream(_fileName, FileMode.Append, FileAccess.Write, FileShare.Delete | FileShare.ReadWrite);
+                _stream = new FileStream(FileName, FileMode.Append, FileAccess.Write, FileShare.Delete | FileShare.ReadWrite);
             }
             await _stream.WriteAsync(data, offset, count);
         }
@@ -36,9 +45,9 @@ namespace Downloader
         public void Clear()
         {
             _stream?.Dispose();
-            if (File.Exists(_fileName))
+            if (File.Exists(FileName))
             {
-                File.Delete(_fileName);
+                File.Delete(FileName);
             }
         }
 


### PR DESCRIPTION
Hi again,
continuing with my saga of pause/resume downloads, I found another problem: I can only start/pause a download if the app is running, but to restore a paused download after reopen the app, I need to recreate the `Package` object.

I serialize it to a JSON file, but I can't set a new `FileStorage` to resume my download 'cause it has only a constructor that creates a new temp file, so the download starts from the beginning.

That's what I need: a public getter to the `FileName` and a constructor on `FileStorage` that receives a string to the new file. I tested it with a custom `FileStorage` with this constructor, so I recreated the package and it works.