### PR TITLE
Close/Flush Storage stream when cancel requested.

### DIFF
--- a/src/Downloader/ChunkDownloader.cs
+++ b/src/Downloader/ChunkDownloader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -101,6 +101,11 @@ namespace Downloader
                     ProgressedByteSize = readSize,
                     ReceivedBytes = buffer.Take(readSize).ToArray()
                 });
+
+                if (token.IsCancellationRequested)
+                {
+                    Chunk.Storage.Close();
+                }
             }
         }
 


### PR DESCRIPTION
Prevents cases where the file handle will be let go before writing the part-full buffer.

I discovered this when serialising the Package to disk and attempting to resume downloads after an application restart, the Chunks were missing data preventing the resume.