### PR TITLE
Remove Debugger.Break

### DIFF
--- a/src/Downloader/DownloadService.cs
+++ b/src/Downloader/DownloadService.cs
@@ -158,7 +158,7 @@ namespace Downloader
             catch (Exception exp)
             {
                 OnDownloadFileCompleted(new AsyncCompletedEventArgs(exp, false, Package));
-                Debugger.Break();
+                
                 throw;
             }
             finally


### PR DESCRIPTION
I'm trying to using [Polly](https://github.com/App-vNext/Polly) to make retries when there are any exceptions throw, but there's a `Debugger.Break()` in `DownloadService.StartDownload()`, so when the exception throw, the debugger will be break instead of retry