### PR TITLE
Added new feature for Ranged Downloads

### DIFF
--- a/src/Downloader.Test/UnitTests/ChunkHubTest.cs
+++ b/src/Downloader.Test/UnitTests/ChunkHubTest.cs
@@ -115,6 +115,81 @@ namespace Downloader.Test.UnitTests
             // assert
             Assert.AreEqual(fileSize, chunks.Sum(chunk => chunk.Length));
         }
+        
+        [TestMethod]
+        public void ChunkFileRangeSizeTest()
+        {
+            // arrange
+            int fileSize = 10679630;
+            int parts = 64;
+            long rangeLow = 1024;
+            long rangeHigh = 9679630;
+            long totalBytes = rangeHigh - rangeLow + 1;
+            var chunkHub = new ChunkHub(_configuration);
+
+            // act
+            Chunk[] chunks = chunkHub.ChunkFileRange(fileSize, rangeLow, rangeHigh, parts);
+
+            // assert
+            Assert.AreEqual(totalBytes, chunks.Sum(chunk => chunk.Length));
+            Assert.IsTrue(fileSize >= chunks.Sum(chunk => chunk.Length));
+            Assert.AreEqual(chunks.Last().End, rangeHigh);
+        }
+
+        [TestMethod]
+        public void ChunkFileRangeTooHighTest()
+        {
+            // arrange
+            int fileSize = 10679630;
+            int parts = 64;
+            long rangeLow = 1024;
+            long rangeHigh = 250000000;
+            var chunkHub = new ChunkHub(_configuration);
+
+            // act
+            Chunk[] chunks = chunkHub.ChunkFileRange(fileSize, rangeLow, rangeHigh, parts);
+
+            // assert
+            Assert.IsTrue(fileSize >= chunks.Sum(chunk => chunk.Length));
+            Assert.AreEqual(chunks.Last().End, fileSize - 1);
+        }
+
+        [TestMethod]
+        public void ChunkFileRangeTooLowTest()
+        {
+            // arrange
+            int fileSize = 10679630;
+            int parts = 64;
+            long rangeLow = 4096;
+            long rangeHigh = 2048;
+            var chunkHub = new ChunkHub(_configuration);
+
+            // act
+            Chunk[] chunks = chunkHub.ChunkFileRange(fileSize, rangeLow, rangeHigh, parts);
+
+            // assert
+            Assert.IsTrue(fileSize >= chunks.Sum(chunk => chunk.Length));
+            Assert.AreEqual(chunks.Last().End, rangeHigh);
+        }
+
+        [TestMethod]
+        public void ChunkFileRangeBelowZeroTest()
+        {
+            // arrange
+            int fileSize = 10679630;
+            int parts = 64;
+            long rangeLow = -4096;
+            long rangeHigh = 2048;
+            var chunkHub = new ChunkHub(_configuration);
+
+            // act
+            Chunk[] chunks = chunkHub.ChunkFileRange(fileSize, rangeLow, rangeHigh, parts);
+
+            // assert
+            Assert.IsTrue(fileSize >= chunks.Sum(chunk => chunk.Length));
+            Assert.AreEqual(chunks.First().Start, 0);
+            Assert.AreEqual(chunks.Last().End, rangeHigh);
+        }
 
         [TestMethod]
         public void ChunkFileZeroSizeTest()

--- a/src/Downloader/ChunkDownloader.cs
+++ b/src/Downloader/ChunkDownloader.cs
@@ -103,10 +103,20 @@ namespace Downloader
         private void SetRequestRange(HttpWebRequest request)
         {
             // has limited range
-            if (Chunk.End > 0 &&
-                (Configuration.ChunkCount > 1 || Chunk.Position > 0))
+            if (Configuration.RangeDownload)
             {
-                request.AddRange(Chunk.Start + Chunk.Position, Chunk.End);
+                if (Chunk.End > 0)
+                {
+                    request.AddRange(Chunk.Start + Chunk.Position, Chunk.End);
+                }
+            }
+            else
+            {
+                if (Chunk.End > 0 &&
+                    (Configuration.ChunkCount > 1 || Chunk.Position > 0))
+                {
+                    request.AddRange(Chunk.Start + Chunk.Position, Chunk.End);
+                }
             }
         }
 

--- a/src/Downloader/DownloadConfiguration.cs
+++ b/src/Downloader/DownloadConfiguration.cs
@@ -17,6 +17,9 @@ namespace Downloader
         private string _tempDirectory;
         private string _tempFilesExtension = ".dsc";
         private int _timeout;
+        private bool _rangeDownload;
+        private long _rangeLow;
+        private long _rangeHigh;
 
         public event PropertyChangedEventHandler PropertyChanged = delegate { };
 
@@ -32,6 +35,9 @@ namespace Downloader
             RequestConfiguration = new RequestConfiguration(); // Default requests configuration
             TempDirectory = Path.GetTempPath(); // Default chunks path
             CheckDiskSizeBeforeDownload = true; // check disk size for temp and file path
+            RangeDownload = false; // enable ranged download
+            RangeLow = 0; // starting byte offset
+            RangeHigh = 0; // ending byte offset
         }
 
         /// <summary>
@@ -138,6 +144,45 @@ namespace Downloader
             set
             {
                 _parallelDownload=value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Download a range of byte
+        /// </summary>
+        public bool RangeDownload
+        {
+            get => _rangeDownload;
+            set
+            {
+                _rangeDownload=value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// The starting byte offset for ranged download
+        /// </summary>
+        public long RangeLow
+        {
+            get => _rangeLow;
+            set
+            {
+                _rangeLow=value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// The ending byte offset for ranged download
+        /// </summary>
+        public long RangeHigh
+        {
+            get => _rangeHigh;
+            set
+            {
+                _rangeHigh=value;
                 OnPropertyChanged();
             }
         }


### PR DESCRIPTION
I added a feature that allows it to download part of a file.  For example, my use case is I need to download a file contained within a much larger zip file without having to download the entire file and unzip.

```
var downloadOpt = new DownloadConfiguration()
            {
                ParallelDownload = true,
                OnTheFlyDownload = true,
                MaxTryAgainOnFailover = 4,
                ChunkCount = 4,
                RangeDownload = true,
                RangeLow = 273618157,
                RangeHigh = 305178560,
            };
```
This was accomplished by creating a ChunkFIleRange function that creates chunks from a given range.

I made other changes so it properly calculates percent complete.

So far the changes are working for my use case. 

I'm sure this will require a lot more tests and testing. 