### PR TITLE
Added ability to have a different number of chunks vs number of downloads in parallel

### DIFF
--- a/src/Downloader/DownloadConfiguration.cs
+++ b/src/Downloader/DownloadConfiguration.cs
@@ -14,6 +14,7 @@ namespace Downloader
         private int _maxTryAgainOnFailover;
         private bool _onTheFlyDownload;
         private bool _parallelDownload;
+        private int _parallelCount;
         private string _tempDirectory;
         private string _tempFilesExtension = ".dsc";
         private int _timeout;
@@ -27,6 +28,7 @@ namespace Downloader
         {
             MaxTryAgainOnFailover = int.MaxValue; // the maximum number of times to fail.
             ParallelDownload = false; // download parts of file as parallel or not
+            ParallelCount = 0; // number of parallel downloads
             ChunkCount = 1; // file parts to download
             Timeout = 1000; // timeout (millisecond) per stream block reader
             OnTheFlyDownload = true; // caching in-memory mode
@@ -147,6 +149,23 @@ namespace Downloader
                 OnPropertyChanged();
             }
         }
+        
+        /// <summary>
+        /// Count of chunks to download in parallel.
+        ///
+        /// If ParallelCount is &lt;=0, then ParallelCount is equal to ChunkCount.
+        /// </summary>
+        public int ParallelCount
+        {
+            get => _parallelCount <= 0 ? ChunkCount : _parallelCount;
+            set
+            {
+                _parallelCount=value;
+                OnPropertyChanged();
+            }
+        }
+
+
 
         /// <summary>
         /// Download a range of byte

--- a/src/Downloader/DownloadConfiguration.cs
+++ b/src/Downloader/DownloadConfiguration.cs
@@ -165,8 +165,6 @@ namespace Downloader
             }
         }
 
-
-
         /// <summary>
         /// Download a range of byte
         /// </summary>

--- a/src/Downloader/DownloadProgressChangedEventArgs.cs
+++ b/src/Downloader/DownloadProgressChangedEventArgs.cs
@@ -57,5 +57,10 @@ namespace Downloader
         /// </summary>
         /// <returns>A byte array that indicates the received bytes.</returns>
         public byte[] ReceivedBytes { get; set; }
+        
+        /// <summary>
+        ///     Gets the number of chunks being downloaded currently.
+        /// </summary>
+        public int ActiveChunks { get; set; }
     }
 }


### PR DESCRIPTION
**Why**
I had a need where I wanted to have a different number of chunks vs number of parallel downloads. This is because in my use case, sometimes one thread would be much slower than the others, and the download would complete 90% of the download in 10% of the time, and that last remaining thread would take 90% of the time. By being able to have more chunks, it reduces the chance that a single chunk dramatically impacts the overall download.

**What Changed**
- Added config option of `ParallelCount` which defaults to `ChunkCount`
- Added `ActiveChunks` to `DownloadProgressChangeEvents`
- Introduced a `SemaphoreSlim` to `DownloadService` to maintain number of active chunks.

**Notes**
- Since `ParallelCount` defaults to `ChunkCount`, existing functionality is not changed.
- Pretty lightweight implementation because of the use of SemaphoreSlim to do the locking.