### PR TITLE
Add ability to define if to clear package chunks in case of completion with failure

### DIFF
--- a/src/Downloader/DownloadConfiguration.cs
+++ b/src/Downloader/DownloadConfiguration.cs
@@ -21,6 +21,7 @@ namespace Downloader
         private bool _rangeDownload;
         private long _rangeLow;
         private long _rangeHigh;
+        private bool _clearPackageOnCompletionWithFailure;
 
         public event PropertyChangedEventHandler PropertyChanged = delegate { };
 
@@ -40,6 +41,7 @@ namespace Downloader
             RangeDownload = false; // enable ranged download
             RangeLow = 0; // starting byte offset
             RangeHigh = 0; // ending byte offset
+            ClearPackageOnCompletionWithFailure = true; // clear package or not when download completed with failure
         }
 
         /// <summary>
@@ -244,6 +246,19 @@ namespace Downloader
             set
             {
                 _timeout=value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Clear package when download completed with failure
+        /// </summary>
+        public bool ClearPackageOnCompletionWithFailure
+        {
+            get => _clearPackageOnCompletionWithFailure;
+            set
+            {
+                _clearPackageOnCompletionWithFailure=value;
                 OnPropertyChanged();
             }
         }

--- a/src/Downloader/DownloadService.cs
+++ b/src/Downloader/DownloadService.cs
@@ -224,7 +224,7 @@ namespace Downloader
             }
             finally
             {
-                if (IsCancelled)
+                if (!Package.IsSaveComplete && (IsCancelled || !Options.ClearPackageOnCompletionWithFailure))
                 {
                     // flush streams
                     Package.Flush();
@@ -269,7 +269,7 @@ namespace Downloader
         {
             if (Options.RangeDownload)
             {
-                if(!Package.IsSupportDownloadInRange)
+                if (!Package.IsSupportDownloadInRange)
                 {
                     throw new NotSupportedException("The server of your desired address does not support download in a specific range");
                 }


### PR DESCRIPTION
Hi
I added an option to define in the `DownloadConfiguration ` if to clear the package chunks after download completed with failure.
The reason for that:
Sometimes I want to have option to resume download from the position it failed , and not to restart the download. for example: If network was disconnected, I want the option that after reconnection of the network, to be able to resume from last position.
(Probably, there is a need to add a unit test for that.)