### PR TITLE
Copy/Merge progress notifications

### DIFF
--- a/src/Downloader/ChunkHub.cs
+++ b/src/Downloader/ChunkHub.cs
@@ -75,8 +75,7 @@ namespace Downloader
         {
             ChunkMergeProgressChanged?.Invoke(this, e);
         }
-        
-        
+
         public async Task MergeChunks(IEnumerable<Chunk> chunks, Stream destinationStream, CancellationToken cancellationToken)
         {
             var chunkList = chunks.ToList(); //Convert to list to prevent multiple enumeration

--- a/src/Downloader/ChunkMergeProgressChangedEventArgs.cs
+++ b/src/Downloader/ChunkMergeProgressChangedEventArgs.cs
@@ -1,0 +1,67 @@
+﻿using System;
+
+namespace Downloader;
+
+public class ChunkMergeProgressChangedEventArgs : EventArgs
+{
+    public ChunkMergeProgressChangedEventArgs(string id)
+    {
+        ProgressId = id ?? "Main";
+    }
+
+    /// <summary>
+    ///     Progress unique identity
+    /// </summary>
+    public string ProgressId { get; }
+
+    /// <summary>
+    ///     Gets the asynchronous task progress percentage.
+    /// </summary>
+    /// <returns>A percentage value indicating the asynchronous task progress.</returns>
+    public double ProgressPercentage => TotalBytesToCopy == 0 ? 0 : ((double)TotalCopiedBytesSize * 100) / TotalBytesToCopy;
+    
+    /// <summary>
+    ///     The size of the chunk we are currently working on
+    /// </summary>
+    public double ChunkSize { get; internal set; }
+    
+    /// <summary>
+    ///     Gets the progress of the copy of the current chunk
+    /// </summary>
+    /// <returns>A percentage value indicating the asynchronous task progress.</returns>
+    public double ChunkProgressPercentage => ChunkSize == 0 ? 0 : ((double)ChunkCopiedBytesSize * 100) / ChunkSize;
+
+    /// <summary>
+    ///     Gets the number of copied bytes.
+    /// </summary>
+    /// <returns>An System.Int64 value that indicates the number of received bytes.</returns>
+    public long TotalCopiedBytesSize { get; internal set; }
+    
+    /// <summary>
+    ///     Gets the number of bytes copied in current chunk.
+    /// </summary>
+    /// <returns>An System.Int64 value that indicates the number of received bytes.</returns>
+    public long ChunkCopiedBytesSize { get; internal set; }
+
+    /// <summary>
+    ///     Gets the total number of bytes in the copy operation
+    /// </summary>
+    /// <returns>An System.Int64 value that indicates the number of bytes that will be copied.</returns>
+    public long TotalBytesToCopy { get; internal set; }
+
+    /// <summary>
+    ///     How many bytes copied per second
+    /// </summary>
+    public double BytesPerSecondSpeed { get; internal set; }
+
+    /// <summary>
+    ///     Average copy speed
+    /// </summary>
+    public double AverageBytesPerSecondSpeed { get; internal set; }
+
+    /// <summary>
+    ///     How many bytes progressed per this time
+    /// </summary>
+    public long ProgressedByteSize { get; internal set; }
+    
+}

--- a/src/Downloader/ChunkMergeProgressChangedEventArgs.cs
+++ b/src/Downloader/ChunkMergeProgressChangedEventArgs.cs
@@ -63,5 +63,4 @@ public class ChunkMergeProgressChangedEventArgs : EventArgs
     ///     How many bytes progressed per this time
     /// </summary>
     public long ProgressedByteSize { get; internal set; }
-    
 }

--- a/src/Downloader/ChunkMergeStartedEventArgs.cs
+++ b/src/Downloader/ChunkMergeStartedEventArgs.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Downloader;
+
+public class ChunkMergeStartedEventArgs : EventArgs
+{
+    public ChunkMergeStartedEventArgs(string fileName, long totalBytes)
+    {
+        TotalBytesToCopy = totalBytes;
+        FileName = fileName;
+    }
+
+    /// <summary>
+    ///     Gets the total number of bytes in the copy operation
+    /// </summary>
+    /// <returns>An System.Int64 value that indicates the number of bytes that will be copied.</returns>
+    public long TotalBytesToCopy { get; internal set; }
+    
+    /// <summary>
+    ///     The name of file which is being merged to
+    /// </summary>
+    public string FileName { get; }
+}

--- a/src/Samples/Downloader.Sample/DownloadList.json
+++ b/src/Samples/Downloader.Sample/DownloadList.json
@@ -1,12 +1,4 @@
 [
-  //{
-  //  "FileName": "D:\\TestDownload\\Hello - 81606.mp4",
-  //  "Url": "https://cdn.pixabay.com/vimeo/576083058/Hello%20-%2081605.mp4?width=1920&hash=e6f56273dcd2f28fd1a9fe6e77f66d7e157b33f6&download=1"
-  //},
-  //{
-  //  "FileName": "D:\\TestDownload\\VS.exe",
-  //  "Url": "https://c2rsetup.officeapps.live.com/c2r/downloadVS.aspx?sku=community&channel=Release&version=VS2022&source=VSLandingPage&includeRecommended=true&cid=2030:9bf2104738684908988ca7dcd5dafed1"
-  //},
   {
     "FileName": "D:\\TestDownload\\LocalFile100MB_Raw.dat",
     "Url": "http://localhost:3333/dummyfile/file/size/104857600"


### PR DESCRIPTION
This implements/resolves the feature requested in #109 . 
It adds 3 events to the download service:
-  OnChunkMergeStarted
-  OnChunkMergeProgressChanged
-  OnChunkMergeCompleted

I was unsure weather to call them Chunk Merge or Copy. This implementation works by adding an event in ChunkHub for ChunkMergeProgressChanged. Using an implementation of CopyToAsync with progress notifications in MergeChunks. 

The ChunkMergeProgressChanged event gives data about the progress of the current chunk being merged, and also the total progress of the merge, and also the speed of the copy utilizing a bandwidth object.

Regrettably I used Copy and Merge interchangeably. I wrote this in just a couple of hours using a lot of copy and paste from other data types, so some comments might be using wrong wording and need to be fixed. If you have any recommendations for changes I would be happy to implement them.  

I do believe that in a perfect implementation of this you would divide the download progress by 2 and also factor in Chunk merge progress in it, but I wanted to add functionality without changing how other functionality works. 
