### PR TITLE
Clarify Timeouts and make HTTPClient timeout configureable

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ var downloadOpt = new DownloadConfiguration()
     // number of parallel downloads. The default value is the same as the chunk count
     ParallelCount = 4,    
     // timeout (millisecond) per stream block reader, default values is 1000
-    Timeout = 1000,      
+    BlockTimeout = 1000,
+    // timeout (millisecond) per HttpClientRequest, default values is 100 Seconds
+    HTTPClientTimeout = 100 * 1000,
     // set true if you want to download just a specific range of bytes of a large file
     RangeDownload = false,
     // floor offset of download range of a large file

--- a/src/Downloader.Test/IntegrationTests/DownloadIntegrationTest.cs
+++ b/src/Downloader.Test/IntegrationTests/DownloadIntegrationTest.cs
@@ -682,7 +682,7 @@ public abstract class DownloadIntegrationTest : BaseTestClass, IDisposable
         Config.MaxTryAgainOnFailure = 5;
         Config.BufferBlockSize = 1024;
         Config.MinimumSizeOfChunking = 0;
-        Config.Timeout = 100;
+        Config.BlockTimeout = 100;
         Config.ClearPackageOnCompletionWithFailure = false;
         DownloadService downloadService = new(Config);
         TaskCompletionSource<bool> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Downloader.Test/IntegrationTests/DownloadServiceTest.cs
+++ b/src/Downloader.Test/IntegrationTests/DownloadServiceTest.cs
@@ -37,9 +37,9 @@ public class DownloadServiceTest : DownloadService
             ParallelDownload = true,
             MaxTryAgainOnFailure = 5,
             MinimumSizeOfChunking = 0,
-            Timeout = 3000,
+            BlockTimeout = 3000,
             RequestConfiguration = new RequestConfiguration {
-                Timeout = 3000,
+                ConnectTimeout = 3000,
                 AllowAutoRedirect = true,
                 KeepAlive = false,
                 UserAgent = "test",
@@ -95,7 +95,7 @@ public class DownloadServiceTest : DownloadService
         string address = "https://nofile";
         Filename = Path.GetTempFileName();
         Options = GetDefaultConfig();
-        Options.RequestConfiguration.Timeout = 300_000; // if this timeout is not set, the test will fail
+        Options.RequestConfiguration.ConnectTimeout = 300_000; // if this timeout is not set, the test will fail
         Options.MaxTryAgainOnFailure = 0;
         DownloadFileCompleted += (_, e) => {
             onCompletionException = e.Error;

--- a/src/Downloader.Test/UnitTests/ChunkDownloaderOnFileTest.cs
+++ b/src/Downloader.Test/UnitTests/ChunkDownloaderOnFileTest.cs
@@ -12,7 +12,7 @@ public class ChunkDownloaderOnFileTest : ChunkDownloaderTest
             ParallelCount = 8,
             MaxTryAgainOnFailure = 100,
             MinimumSizeOfChunking = 16,
-            Timeout = 100,
+            BlockTimeout = 100,
         };
         Storage = new ConcurrentStream(path, 0);
     }

--- a/src/Downloader.Test/UnitTests/ChunkDownloaderOnMemoryTest.cs
+++ b/src/Downloader.Test/UnitTests/ChunkDownloaderOnMemoryTest.cs
@@ -10,7 +10,7 @@ public class ChunkDownloaderOnMemoryTest : ChunkDownloaderTest
             ParallelDownload = true,
             MaxTryAgainOnFailure = 100,
             MinimumSizeOfChunking = 16,
-            Timeout = 100
+            BlockTimeout = 100
         };
         Storage = new ConcurrentStream(null);
     }

--- a/src/Downloader.Test/UnitTests/ChunkDownloaderTest.cs
+++ b/src/Downloader.Test/UnitTests/ChunkDownloaderTest.cs
@@ -12,7 +12,7 @@ public abstract class ChunkDownloaderTest(ITestOutputHelper output) : BaseTestCl
         // arrange
         byte[] randomlyBytes = DummyData.GenerateRandomBytes(Size);
         Chunk chunk = new(0, Size - 1) { Timeout = 1000 };
-        ChunkDownloader chunkDownloader = new(chunk, Configuration, Storage, new SocketClient(Configuration.RequestConfiguration));
+        ChunkDownloader chunkDownloader = new(chunk, Configuration, Storage, new SocketClient(Configuration));
         using MemoryStream memoryStream = new(randomlyBytes);
 
         // act
@@ -36,7 +36,7 @@ public abstract class ChunkDownloaderTest(ITestOutputHelper output) : BaseTestCl
         // arrange            
         byte[] randomlyBytes = DummyData.GenerateRandomBytes(Size);
         Chunk chunk = new(0, Size - 1) { Timeout = 100 };
-        ChunkDownloader chunkDownloader = new(chunk, Configuration, Storage, new SocketClient(Configuration.RequestConfiguration));
+        ChunkDownloader chunkDownloader = new(chunk, Configuration, Storage, new SocketClient(Configuration));
         using MemoryStream memoryStream = new(randomlyBytes);
         PauseTokenSource pauseToken = new();
         int pauseCount = 0;
@@ -72,7 +72,7 @@ public abstract class ChunkDownloaderTest(ITestOutputHelper output) : BaseTestCl
         using MemoryStream sourceMemoryStream = new(source);
         Chunk chunk = new(0, Size - 1) { Timeout = 100 };
         Configuration.EnableLiveStreaming = true;
-        ChunkDownloader chunkDownloader = new(chunk, Configuration, Storage, new SocketClient(Configuration.RequestConfiguration));
+        ChunkDownloader chunkDownloader = new(chunk, Configuration, Storage, new SocketClient(Configuration));
         chunkDownloader.DownloadProgressChanged += (_, e) => {
             eventCount++;
             receivedBytes.AddRange(e.ReceivedBytes);
@@ -95,7 +95,7 @@ public abstract class ChunkDownloaderTest(ITestOutputHelper output) : BaseTestCl
         // arrange
         byte[] randomlyBytes = DummyData.GenerateRandomBytes(Size);
         Chunk chunk = new(0, Size - 1) { Timeout = 100 };
-        ChunkDownloader chunkDownloader = new(chunk, Configuration, Storage, new SocketClient(Configuration.RequestConfiguration));
+        ChunkDownloader chunkDownloader = new(chunk, Configuration, Storage, new SocketClient(Configuration));
         using MemoryStream memoryStream = new(randomlyBytes);
         CancellationToken canceledToken = new(true);
 
@@ -115,7 +115,7 @@ public abstract class ChunkDownloaderTest(ITestOutputHelper output) : BaseTestCl
         CancellationTokenSource cts = new();
         byte[] randomlyBytes = DummyData.GenerateRandomBytes(Size);
         Chunk chunk = new(0, Size - 1) { Timeout = 0 };
-        ChunkDownloader chunkDownloader = new(chunk, Configuration, Storage, new SocketClient(Configuration.RequestConfiguration));
+        ChunkDownloader chunkDownloader = new(chunk, Configuration, Storage, new SocketClient(Configuration));
         using MemoryStream memoryStream = new(randomlyBytes);
         ThrottledStream slowStream = new(memoryStream, Configuration.BufferBlockSize);
 
@@ -140,7 +140,7 @@ public abstract class ChunkDownloaderTest(ITestOutputHelper output) : BaseTestCl
         byte[] randomlyBytes = DummyData.GenerateSingleBytes(Size, 200);
         CancellationTokenSource cts = new();
         Chunk chunk = new(0, Size - 1) { Id = "Test_Chunk", Timeout = 3000 };
-        ChunkDownloader chunkDownloader = new(chunk, Configuration, Storage, new SocketClient(Configuration.RequestConfiguration));
+        ChunkDownloader chunkDownloader = new(chunk, Configuration, Storage, new SocketClient(Configuration));
         MemoryStream memoryStream = new(randomlyBytes);
         chunkDownloader.DownloadProgressChanged += (_, e) => {
             if (e.ProgressPercentage > 50)
@@ -188,7 +188,7 @@ public abstract class ChunkDownloaderTest(ITestOutputHelper output) : BaseTestCl
         // arrange
         byte[] randomlyBytes = DummyData.GenerateRandomBytes(Size);
         Chunk chunk = new(0, (Size / 2) - 1);
-        ChunkDownloader chunkDownloader = new(chunk, Configuration, Storage, new SocketClient(Configuration.RequestConfiguration));
+        ChunkDownloader chunkDownloader = new(chunk, Configuration, Storage, new SocketClient(Configuration));
         using MemoryStream memoryStream = new(randomlyBytes);
 
         // act

--- a/src/Downloader.Test/UnitTests/ChunkHubTest.cs
+++ b/src/Downloader.Test/UnitTests/ChunkHubTest.cs
@@ -3,7 +3,7 @@
 public class ChunkHubTest(ITestOutputHelper output) : BaseTestClass(output)
 {
     private readonly DownloadConfiguration _config = new() {
-        Timeout = 100,
+        BlockTimeout = 100,
         MaxTryAgainOnFailure = 100,
         BufferBlockSize = 1024
     };

--- a/src/Downloader.Test/UnitTests/DownloadConfigurationTest.cs
+++ b/src/Downloader.Test/UnitTests/DownloadConfigurationTest.cs
@@ -57,7 +57,7 @@ public class DownloadConfigurationTest(ITestOutputHelper output) : BaseTestClass
             MaxTryAgainOnFailure = 100,
             ParallelDownload = true,
             ChunkCount = 1,
-            Timeout = 150,
+            BlockTimeout = 150,
             BufferBlockSize = 2048,
             MaximumBytesPerSecond = 1024,
             RequestConfiguration = new RequestConfiguration(),

--- a/src/Downloader.Test/UnitTests/SocketClientTest.cs
+++ b/src/Downloader.Test/UnitTests/SocketClientTest.cs
@@ -2,7 +2,7 @@ namespace Downloader.Test.UnitTests;
 
 public class SocketClientTest(ITestOutputHelper output) : BaseTestClass(output)
 {
-    private readonly SocketClient _socketClient = new(new RequestConfiguration());
+    private readonly SocketClient _socketClient = new(new DownloadConfiguration());
 
     [Fact]
     public async Task GetUrlDispositionWhenNoUrlFileNameTest()

--- a/src/Downloader/AbstractDownloadService.cs
+++ b/src/Downloader/AbstractDownloadService.cs
@@ -333,7 +333,7 @@ public abstract class AbstractDownloadService : IDownloadService, IDisposable, I
         Status = DownloadStatus.Created;
         GlobalCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         TaskCompletion = new TaskCompletionSource<AsyncCompletedEventArgs>();
-        Client = new SocketClient(Options.RequestConfiguration);
+        Client = new SocketClient(Options);
         RequestInstances = addresses.Select(url => new Request(url, Options.RequestConfiguration)).ToList();
         Package.Urls = RequestInstances.Select(req => req.Address.OriginalString).ToArray();
         ChunkHub = new ChunkHub(Options);

--- a/src/Downloader/ChunkHub.cs
+++ b/src/Downloader/ChunkHub.cs
@@ -95,7 +95,7 @@ public class ChunkHub
         Chunk chunk = new(start, end) {
             Id = id,
             MaxTryAgainOnFailure = _config.MaxTryAgainOnFailure,
-            Timeout = _config.Timeout
+            Timeout = _config.BlockTimeout
         };
 
         return chunk;

--- a/src/Downloader/DownloadConfiguration.cs
+++ b/src/Downloader/DownloadConfiguration.cs
@@ -18,7 +18,8 @@ public class DownloadConfiguration : ICloneable, INotifyPropertyChanged
     private bool _checkDiskSizeBeforeDownload = true; // check disk size for temp and file path
     private bool _parallelDownload; // download parts of file as parallel or not
     private int _parallelCount; // number of parallel downloads
-    private int _timeout = 1000; // timeout (millisecond) per stream block reader
+    private int _blockTimeout = 1000; // timeout (millisecond) per stream block reader
+    private int _httpClientTimeout = 100 * 1000; // timeount (millisecond) for the httpClient
     private bool _rangeDownload; // enable ranged download
     private long _rangeLow; // starting byte offset
     private long _rangeHigh; // ending byte offset
@@ -191,15 +192,30 @@ public class DownloadConfiguration : ICloneable, INotifyPropertyChanged
     /// <summary>
     /// Gets or sets the download timeout per stream file blocks.
     /// </summary>
-    public int Timeout
+    public int BlockTimeout
     {
-        get => _timeout;
+        get => _blockTimeout;
         set
         {
             if (value < 100)
-                throw new ArgumentOutOfRangeException(nameof(Timeout),
+                throw new ArgumentOutOfRangeException(nameof(BlockTimeout),
                     "Timeout must be at least 100 milliseconds");
-            OnPropertyChanged(ref _timeout, value);
+            OnPropertyChanged(ref _blockTimeout, value);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the timeout for the HTTPClient in Milliseconds
+    /// </summary>
+    public int HTTPClientTimeout
+    {
+        get => _httpClientTimeout;
+        set
+        {
+            if (value < 1000)
+                throw new ArgumentOutOfRangeException(nameof(HTTPClientTimeout),
+                    "Timeout must be at least 1000 milliseconds");
+            OnPropertyChanged(ref _httpClientTimeout, value);
         }
     }
 

--- a/src/Downloader/RequestConfiguration.cs
+++ b/src/Downloader/RequestConfiguration.cs
@@ -28,7 +28,7 @@ public class RequestConfiguration
         MaximumAutomaticRedirections = 50;
         Pipelined = true;
         ProtocolVersion = HttpVersion.Version11;
-        Timeout = 30 * 1000; // 30 seconds
+        ConnectTimeout = 30 * 1000; // 30 seconds
         UserAgent = $"{nameof(Downloader)}/{Assembly.GetExecutingAssembly().GetName().Version?.ToString(3)}";
     }
 
@@ -234,9 +234,9 @@ public class RequestConfiguration
     public bool SendChunked { get; set; }
 
     /// <summary>
-    /// Gets or sets the timeout value in milliseconds for the request and response of http web methods.
+    /// Gets or sets the timeout value in milliseconds for the the connection to be established
     /// </summary>
-    public int Timeout { get; set; }
+    public int ConnectTimeout { get; set; }
 
     /// <summary>
     /// A String that contains the value of the HTTP Transfer-encoding header. The default value is null.

--- a/src/Samples/Downloader.Sample/Program.Config.cs
+++ b/src/Samples/Downloader.Sample/Program.Config.cs
@@ -18,7 +18,8 @@ public partial class Program
             MaxTryAgainOnFailure = 50_000,  // the maximum number of times to fail
             MaximumMemoryBufferBytes = 1024 * 1024 * 500, // release memory buffer after each 500MB
             ParallelDownload = true,    // download parts of file as parallel or not. Default value is false
-            Timeout = 3000,             // timeout (millisecond) per stream block reader, default value is 1000
+            BlockTimeout = 3000,             // timeout (millisecond) per stream block reader, default value is 1000
+            HTTPClientTimeout = 3000,   // Timeout of the http client
             RangeDownload = false,      // set true if you want to download just a specific range of bytes of a large file
             RangeLow = 0,               // floor offset of download range of a large file
             RangeHigh = 0,              // ceiling offset of download range of a large file


### PR DESCRIPTION
Renamed `Timeout` in `RequestConfiguration` to `ConnectTimeout`, as this value only applies to establishing a connection—not the full HTTP request/response cycle.  
[Source](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.socketshttphandler.connecttimeout?view=net-9.0)

Renamed `Timeout` to `BlockTimeout`, since it refers to the timeout for a single block.

Added `HttpClientTimeout` to control the timeout for an entire HTTP request.  
Not sure how useful this is, as it overlaps with `BlockTimeout`.  
I’d also be fine setting `HttpClient.Timeout` to `BlockTimeout` instead and removing the HttpClientTimeout option.
Feedback on this is welcome.

I noticed this issue while debugging downloads that exceeded 100 seconds (the default value of `HttpClient.Timeout`).  
Regardless of how I set the two timeouts, the request always failed after 100 seconds.  
We could consider writing a test for this, but I’m not very experienced with testing.
