### PR TITLE
Fix CanWrite condition

### DIFF
--- a/src/Downloader/Chunk.cs
+++ b/src/Downloader/Chunk.cs
@@ -60,7 +60,7 @@ public class Chunk
     /// <summary>
     /// Gets a value indicating whether more data can be written to this chunk according to the chunk's situation.
     /// </summary>
-    [JsonIgnore] public bool CanWrite => Length <= 0 || Start + Position < End;
+    [JsonIgnore] public bool CanWrite => Length <= 0 || Start + Position <= End;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Chunk"/> class with default values.


### PR DESCRIPTION
The `BlockSize` is 1024 by default. When a file is divided into exactly 1025 bytes each chunk. The ChunkDownloader will download 1024 bytes first, and write to the chunk Stream.

After that, the Chunk Position will be changed to 1024, however, there is still 1 byte of stream to be downloaded.

The `Start + Position < End` will be false. Because 0+1024<1024. Change it to `Start + Position <= End` can fix the problem.