### PR TITLE
Fix #223: URI encode links

### DIFF
--- a/src/Downloader.Test/UnitTests/UrlHelperTest.cs
+++ b/src/Downloader.Test/UnitTests/UrlHelperTest.cs
@@ -1,0 +1,156 @@
+using Downloader.Extensions;
+
+namespace Downloader.Test.UnitTests;
+
+public class UrlHelperTest(ITestOutputHelper output) : BaseTestClass(output)
+{
+    [Theory]
+    // Null / empty / whitespace passthrough
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    // No scheme: left alone (not an absolute URL we can safely decompose)
+    [InlineData("relative/path", "relative/path")]
+    [InlineData("/just/a/path[1].mkv", "/just/a/path[1].mkv")]
+    // Plain URLs pass through unchanged
+    [InlineData("http://example.com/", "http://example.com/")]
+    [InlineData("http://example.com/path/to/file.mkv", "http://example.com/path/to/file.mkv")]
+    [InlineData("https://example.com", "https://example.com")]
+    // Bracketed release tags (the motivating bug, issue #223)
+    [InlineData(
+        "https://real-debrid.com/d/ABCDEF/[SubGroup] Series - 03 [1080p WEB-DL].mkv",
+        "https://real-debrid.com/d/ABCDEF/%5BSubGroup%5D%20Series%20-%2003%20%5B1080p%20WEB-DL%5D.mkv")]
+    // Curly braces
+    [InlineData(
+        "https://example.com/a/{token}/file.bin",
+        "https://example.com/a/%7Btoken%7D/file.bin")]
+    // Unencoded spaces in path
+    [InlineData(
+        "http://example.com/My Docs/report.pdf",
+        "http://example.com/My%20Docs/report.pdf")]
+    // Pipe, caret, backtick, double-quote, angle brackets — all illegal in path
+    [InlineData(
+        "http://example.com/a|b^c`d\"e<f>g.txt",
+        "http://example.com/a%7Cb%5Ec%60d%22e%3Cf%3Eg.txt")]
+    // Query string preserved verbatim (we only touch the path)
+    [InlineData(
+        "https://example.com/[x]/file.mkv?token=a[b]c&y=1",
+        "https://example.com/%5Bx%5D/file.mkv?token=a[b]c&y=1")]
+    // Fragment preserved verbatim
+    [InlineData(
+        "https://example.com/[x]/file.mkv#frag[ment]",
+        "https://example.com/%5Bx%5D/file.mkv#frag[ment]")]
+    // Query AND fragment together
+    [InlineData(
+        "https://example.com/[x]/file.mkv?q=1#frag",
+        "https://example.com/%5Bx%5D/file.mkv?q=1#frag")]
+    // IPv6 literal in host must NOT be touched
+    [InlineData(
+        "http://[::1]:8080/path[1].mkv",
+        "http://[::1]:8080/path%5B1%5D.mkv")]
+    [InlineData(
+        "http://[2001:db8::1]/a b.txt",
+        "http://[2001:db8::1]/a%20b.txt")]
+    // Userinfo preserved
+    [InlineData(
+        "http://user:pass@example.com/dir[1]/file.mkv",
+        "http://user:pass@example.com/dir%5B1%5D/file.mkv")]
+    // pchar sub-delims and ':' '@' are preserved (legal in path)
+    [InlineData(
+        "http://example.com/a!$&'()*+,;=:@b.mkv",
+        "http://example.com/a!$&'()*+,;=:@b.mkv")]
+    // Non-http schemes work too (path is still path)
+    [InlineData(
+        "file:///home/user/[media]/show.mkv",
+        "file:///home/user/%5Bmedia%5D/show.mkv")]
+    // Already-encoded input is preserved (idempotency, single pass)
+    [InlineData(
+        "https://example.com/%5BSubGroup%5D/file.mkv",
+        "https://example.com/%5BSubGroup%5D/file.mkv")]
+    // Lowercase hex in existing triplets gets normalized to uppercase
+    [InlineData(
+        "https://example.com/%5bx%5d/file.mkv",
+        "https://example.com/%5Bx%5D/file.mkv")]
+    // Standalone '%' not followed by two hex digits must be encoded to %25
+    [InlineData(
+        "http://example.com/50%off.mkv",
+        "http://example.com/50%25off.mkv")]
+    [InlineData(
+        "http://example.com/%",
+        "http://example.com/%25")]
+    [InlineData(
+        "http://example.com/%Z1/file",
+        "http://example.com/%25Z1/file")]
+    // Authority-only URL with no path
+    [InlineData("http://example.com?q=1", "http://example.com?q=1")]
+    [InlineData("http://example.com#frag", "http://example.com#frag")]
+    public void EnsurePathEncodedTest(string input, string expected)
+    {
+        string actual = UrlHelper.EnsurePathEncoded(input);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void EnsurePathEncodedIsIdempotent()
+    {
+        // Running twice must equal running once for any input we'd see in practice.
+        string[] inputs =
+        [
+            "https://real-debrid.com/d/ABCDEF/[SubGroup] Series - 03 [1080p WEB-DL].mkv",
+            "https://example.com/a/{token}/file.bin",
+            "http://example.com/My Docs/report.pdf",
+            "https://example.com/%5BSubGroup%5D/file.mkv",
+            "http://[::1]:8080/path[1].mkv?q=[x]#frag[1]",
+            "http://example.com/50%off.mkv",
+        ];
+
+        foreach (string input in inputs)
+        {
+            string once = UrlHelper.EnsurePathEncoded(input);
+            string twice = UrlHelper.EnsurePathEncoded(once);
+            Assert.Equal(once, twice);
+        }
+    }
+
+    [Fact]
+    public void EnsurePathEncodedProducesUriParsableOutput()
+    {
+        // The whole point is that after normalization, Uri.TryCreate succeeds
+        // cleanly on every platform — including Linux.
+        string input = "https://real-debrid.com/d/ABCDEF/[SubGroup] Series - 03 [1080p WEB-DL].mkv";
+        string normalized = UrlHelper.EnsurePathEncoded(input);
+
+        Assert.True(Uri.TryCreate(normalized, UriKind.Absolute, out Uri uri));
+        Assert.Equal("real-debrid.com", uri.Host);
+        Assert.DoesNotContain("[", uri.AbsolutePath);
+        Assert.DoesNotContain("]", uri.AbsolutePath);
+        Assert.DoesNotContain(" ", uri.AbsolutePath);
+    }
+
+    [Fact]
+    public void EnsurePathEncodedHandlesUnicodeCorrectly()
+    {
+        // Non-ASCII characters in the path should be UTF-8 percent-encoded.
+        string input = "https://example.com/مستند.pdf";
+        string normalized = UrlHelper.EnsurePathEncoded(input);
+
+        Assert.True(Uri.TryCreate(normalized, UriKind.Absolute, out Uri uri));
+        // Round-trip: decoding the path must give back the original filename.
+        string filename = Uri.UnescapeDataString(Path.GetFileName(uri.AbsolutePath));
+        Assert.Equal("مستند.pdf", filename);
+    }
+
+    [Fact]
+    public void RequestConstructorAcceptsBracketedUrl()
+    {
+        // Integration check: Request no longer falls back to the
+        // http://localhost base when given a URL with illegal path chars.
+        string input = "https://real-debrid.com/d/ABCDEF/[SubGroup] Series - 03 [1080p WEB-DL].mkv";
+
+        Request request = new(input);
+
+        Assert.Equal("real-debrid.com", request.Address.Host);
+        Assert.Equal("https", request.Address.Scheme);
+        Assert.Contains("%5B", request.Address.AbsoluteUri);
+        Assert.Contains("%5D", request.Address.AbsoluteUri);
+    }
+}

--- a/src/Downloader.Test/UnitTests/UrlHelperTest.cs
+++ b/src/Downloader.Test/UnitTests/UrlHelperTest.cs
@@ -83,10 +83,77 @@ public class UrlHelperTest(ITestOutputHelper output) : BaseTestClass(output)
     // Authority-only URL with no path
     [InlineData("http://example.com?q=1", "http://example.com?q=1")]
     [InlineData("http://example.com#frag", "http://example.com#frag")]
+    // Empty path segments (double slash) preserved as-is
+    [InlineData("http://example.com//double//slash/", "http://example.com//double//slash/")]
+    // Very short scheme-only input — no authority, no path
+    [InlineData("http://", "http://")]
     public void EnsurePathEncodedTest(string input, string expected)
     {
         string actual = UrlHelper.EnsurePathEncoded(input);
         Assert.Equal(expected, actual);
+    }
+
+    // -------- Security tests -----------------------------------------------
+    //
+    // These verify that characters with HTTP-level semantic impact (CR/LF for
+    // request-line smuggling, NUL for string-termination bugs, tab for header
+    // parsing, other C0 controls) are always percent-encoded. Encoding, not
+    // stripping, preserves byte identity so the server can apply its own
+    // rejection policies on the original input.
+
+    [Theory]
+    // NOTE: use \uXXXX-style escapes (exact 4 hex digits) not \x — C#'s
+    // \x is a greedy 1-to-4-digit escape, so "\x01b" parses as U+01B (ESC),
+    // not U+0001 followed by literal 'b'.
+    [InlineData("http://example.com/a\rb.txt", "http://example.com/a%0Db.txt")]              // CR
+    [InlineData("http://example.com/a\nb.txt", "http://example.com/a%0Ab.txt")]              // LF
+    [InlineData("http://example.com/a\r\nb.txt", "http://example.com/a%0D%0Ab.txt")]         // CRLF
+    [InlineData("http://example.com/a\tb.txt", "http://example.com/a%09b.txt")]              // Tab
+    [InlineData("http://example.com/a\u0000b.txt", "http://example.com/a%00b.txt")]          // NUL
+    [InlineData("http://example.com/a\u0001b.txt", "http://example.com/a%01b.txt")]          // SOH
+    [InlineData("http://example.com/a\u000Cb.txt", "http://example.com/a%0Cb.txt")]          // FF
+    [InlineData("http://example.com/a\u007Fb.txt", "http://example.com/a%7Fb.txt")]          // DEL
+    // CRLF injection via URL path (HTTP request smuggling attempt) must be
+    // defused — the injected Host header and malicious request tail become
+    // percent-escaped and harmless.
+    [InlineData(
+        "http://example.com/file\r\nHost: evil.com\r\nGET /admin HTTP/1.1",
+        "http://example.com/file%0D%0AHost:%20evil.com%0D%0AGET%20/admin%20HTTP/1.1")]
+    public void EnsurePathEncodedEscapesControlCharacters(string input, string expected)
+    {
+        string actual = UrlHelper.EnsurePathEncoded(input);
+        Assert.Equal(expected, actual);
+        // Sanity: output contains no raw control characters.
+        foreach (char c in actual)
+            Assert.False(c < 0x20 || c == 0x7F, $"control char U+{(int)c:X4} leaked into output");
+    }
+
+    [Fact]
+    public void EnsurePathEncodedDoesNotDecodeExistingEscapes()
+    {
+        // Defense against double-decode smuggling: an attacker-supplied
+        // %2e%2e%2f must reach the server exactly as %2e%2e%2f so that
+        // server-side path-traversal defenses see the true input. The helper
+        // must not unescape on its own initiative.
+        string input = "https://example.com/files/%2e%2e%2fetc%2fpasswd";
+        string actual = UrlHelper.EnsurePathEncoded(input);
+
+        // Lowercase hex is normalized to uppercase, but bytes stay encoded.
+        Assert.Equal("https://example.com/files/%2E%2E%2Fetc%2Fpasswd", actual);
+        Assert.DoesNotContain("..", actual);
+        Assert.DoesNotContain("/etc/", actual);
+    }
+
+    [Fact]
+    public void EnsurePathEncodedDoesNotAlterAuthority()
+    {
+        // Path encoding must never reach into the authority — an attacker
+        // must not be able to influence host resolution via path content.
+        const string maliciousHost = "attacker.example.com";
+        string input = $"http://{maliciousHost}/legit/[path]";
+        string actual = UrlHelper.EnsurePathEncoded(input);
+
+        Assert.StartsWith($"http://{maliciousHost}/", actual);
     }
 
     [Fact]
@@ -149,8 +216,26 @@ public class UrlHelperTest(ITestOutputHelper output) : BaseTestClass(output)
         Request request = new(input);
 
         Assert.Equal("real-debrid.com", request.Address.Host);
+        Assert.NotEqual("localhost", request.Address.Host);
         Assert.Equal("https", request.Address.Scheme);
         Assert.Contains("%5B", request.Address.AbsoluteUri);
         Assert.Contains("%5D", request.Address.AbsoluteUri);
+        Assert.DoesNotContain("[", request.Address.AbsolutePath);
+        Assert.DoesNotContain(" ", request.Address.AbsolutePath);
+    }
+
+    [Fact]
+    public void RequestConstructorHandlesControlCharUrlWithoutInjection()
+    {
+        // Even if a caller somehow supplies a URL containing CRLF (e.g. from
+        // a compromised upstream API), the normalized Address must not carry
+        // raw control chars into the HTTP layer.
+        string input = "http://example.com/a\r\nHost: evil.com/b.txt";
+
+        Request request = new(input);
+
+        Assert.Equal("example.com", request.Address.Host);
+        foreach (char c in request.Address.AbsoluteUri)
+            Assert.False(c < 0x20 || c == 0x7F, "control character reached Address.AbsoluteUri");
     }
 }

--- a/src/Downloader/Extensions/UrlHelper.cs
+++ b/src/Downloader/Extensions/UrlHelper.cs
@@ -11,6 +11,20 @@ namespace Downloader.Extensions;
 /// "[SubGroup] Show - 01 [1080p].mkv". Windows' URI parser is permissive and
 /// tends to hide the problem; Linux' parser is stricter and rejects or
 /// mishandles the URL, causing the downloader to 404 or fail outright.
+///
+/// Security properties:
+///  - Never decodes input. Existing <c>%XX</c> triplets are preserved so that
+///    what the server sees matches exactly what the caller supplied. This
+///    avoids double-decode smuggling (e.g. an attacker supplying
+///    <c>%2e%2e%2f</c> must reach the server as <c>%2e%2e%2f</c>, not as
+///    <c>../</c>, so server-side path-traversal defenses see the real input).
+///  - Encodes all control characters (including CR, LF, NUL, TAB) as UTF-8
+///    percent-escapes, which defuses HTTP request-line smuggling via
+///    injected newlines.
+///  - Touches only the path. The authority (host, userinfo, port, IPv6
+///    literal) is preserved byte-for-byte, so an attacker cannot alter the
+///    destination by crafting path content.
+///  - Output is always safely consumable by <see cref="Uri.TryCreate(string, UriKind, out Uri)"/>.
 /// </summary>
 internal static class UrlHelper
 {
@@ -19,11 +33,17 @@ internal static class UrlHelper
     /// <summary>
     /// Returns the given URL with any path-segment characters that are not
     /// valid pchar per RFC 3986 percent-encoded as UTF-8. Idempotent: existing
-    /// valid <c>%XX</c> triplets are passed through unchanged, so encoding an
-    /// already-encoded URL yields the same string. Only the path is modified —
-    /// scheme, userinfo, host (including IPv6 literal brackets like
-    /// <c>[::1]</c>), port, query, and fragment are preserved byte-for-byte.
-    /// Relative URLs (no scheme) and empty input are returned unchanged.
+    /// valid <c>%XX</c> triplets are passed through unchanged (with hex
+    /// normalized to uppercase), so encoding an already-encoded URL yields the
+    /// same string. Only the path is modified — scheme, userinfo, host
+    /// (including IPv6 literal brackets like <c>[::1]</c>), port, query, and
+    /// fragment are preserved byte-for-byte. Relative URLs (no scheme),
+    /// <c>null</c>, and empty input are returned unchanged.
+    ///
+    /// Note: a raw <c>?</c> or <c>#</c> in the input is treated as the
+    /// query/fragment delimiter per RFC 3986, not as a literal path
+    /// character. Callers that need a literal <c>?</c> or <c>#</c> in a
+    /// filename must pre-encode them as <c>%3F</c> / <c>%23</c>.
     /// </summary>
     public static string EnsurePathEncoded(string address)
     {
@@ -71,7 +91,7 @@ internal static class UrlHelper
 
         string path = address.Substring(pathStart, pathEnd - pathStart);
         string encoded = EncodePath(path);
-        if (ReferenceEquals(encoded, path))
+        if (encoded == path)
             return address;
 
         return address.Substring(0, pathStart) + encoded + address.Substring(pathEnd);

--- a/src/Downloader/Extensions/UrlHelper.cs
+++ b/src/Downloader/Extensions/UrlHelper.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Text;
+
+namespace Downloader.Extensions;
+
+/// <summary>
+/// Normalizes URL strings before they reach <see cref="Uri"/> or the HTTP stack.
+/// Motivating case (issue #223): download URLs whose path contains characters
+/// that are illegal there per RFC 3986 — most commonly square brackets and
+/// unencoded spaces in release-group filenames such as
+/// "[SubGroup] Show - 01 [1080p].mkv". Windows' URI parser is permissive and
+/// tends to hide the problem; Linux' parser is stricter and rejects or
+/// mishandles the URL, causing the downloader to 404 or fail outright.
+/// </summary>
+internal static class UrlHelper
+{
+    private const string HexChars = "0123456789ABCDEF";
+
+    /// <summary>
+    /// Returns the given URL with any path-segment characters that are not
+    /// valid pchar per RFC 3986 percent-encoded as UTF-8. Idempotent: existing
+    /// valid <c>%XX</c> triplets are passed through unchanged, so encoding an
+    /// already-encoded URL yields the same string. Only the path is modified —
+    /// scheme, userinfo, host (including IPv6 literal brackets like
+    /// <c>[::1]</c>), port, query, and fragment are preserved byte-for-byte.
+    /// Relative URLs (no scheme) and empty input are returned unchanged.
+    /// </summary>
+    public static string EnsurePathEncoded(string address)
+    {
+        if (string.IsNullOrEmpty(address))
+            return address;
+
+        // Locate component boundaries manually. We can't use Uri here — Uri is
+        // exactly what rejects these URLs on Linux.
+        int schemeEnd = address.IndexOf("://", StringComparison.Ordinal);
+        if (schemeEnd < 0)
+            return address;
+
+        int authorityStart = schemeEnd + 3;
+
+        // Authority ends at the first '/', '?', or '#' after it starts.
+        int authorityEnd = address.Length;
+        for (int i = authorityStart; i < address.Length; i++)
+        {
+            char c = address[i];
+            if (c == '/' || c == '?' || c == '#')
+            {
+                authorityEnd = i;
+                break;
+            }
+        }
+
+        // No path to encode if authority ran to the end or the next component
+        // isn't a path (i.e. '?' or '#' directly follow authority).
+        if (authorityEnd == address.Length || address[authorityEnd] != '/')
+            return address;
+
+        int pathStart = authorityEnd;
+
+        // Path ends at the first '?' or '#', or at end of string.
+        int pathEnd = address.Length;
+        for (int i = pathStart; i < address.Length; i++)
+        {
+            char c = address[i];
+            if (c == '?' || c == '#')
+            {
+                pathEnd = i;
+                break;
+            }
+        }
+
+        string path = address.Substring(pathStart, pathEnd - pathStart);
+        string encoded = EncodePath(path);
+        if (ReferenceEquals(encoded, path))
+            return address;
+
+        return address.Substring(0, pathStart) + encoded + address.Substring(pathEnd);
+    }
+
+    private static string EncodePath(string path)
+    {
+        // Fast path: if every character is already safe (or a valid %XX
+        // triplet), return the input unchanged and avoid allocating.
+        if (!NeedsEncoding(path))
+            return path;
+
+        var sb = new StringBuilder(path.Length + 16);
+        int i = 0;
+        while (i < path.Length)
+        {
+            char c = path[i];
+
+            if (c == '/' || IsSafeInPathSegment(c))
+            {
+                sb.Append(c);
+                i++;
+                continue;
+            }
+
+            // Pass through already-valid percent-encoded triplets (idempotency).
+            // Normalize hex digits to uppercase so the output is canonical.
+            if (c == '%' && i + 2 < path.Length && IsHex(path[i + 1]) && IsHex(path[i + 2]))
+            {
+                sb.Append('%');
+                sb.Append(ToUpperHex(path[i + 1]));
+                sb.Append(ToUpperHex(path[i + 2]));
+                i += 3;
+                continue;
+            }
+
+            // Encode as UTF-8, preserving surrogate pairs for astral code points.
+            string piece;
+            if (char.IsHighSurrogate(c) && i + 1 < path.Length && char.IsLowSurrogate(path[i + 1]))
+            {
+                piece = path.Substring(i, 2);
+                i += 2;
+            }
+            else
+            {
+                piece = c.ToString();
+                i++;
+            }
+
+            byte[] bytes = Encoding.UTF8.GetBytes(piece);
+            for (int b = 0; b < bytes.Length; b++)
+            {
+                sb.Append('%');
+                sb.Append(HexChars[bytes[b] >> 4]);
+                sb.Append(HexChars[bytes[b] & 0xF]);
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static bool NeedsEncoding(string path)
+    {
+        for (int i = 0; i < path.Length; i++)
+        {
+            char c = path[i];
+            if (c == '/' || IsSafeInPathSegment(c))
+                continue;
+            if (c == '%' && i + 2 < path.Length && IsHex(path[i + 1]) && IsHex(path[i + 2]))
+            {
+                // Also require canonical (uppercase) form; lowercase triplets
+                // are valid but we rewrite them for consistency.
+                if (IsUpperHex(path[i + 1]) && IsUpperHex(path[i + 2]))
+                {
+                    i += 2;
+                    continue;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private static bool IsSafeInPathSegment(char c)
+    {
+        // RFC 3986 pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
+        //   unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
+        //   sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+        if ((uint)(c - 'A') <= 'Z' - 'A') return true;
+        if ((uint)(c - 'a') <= 'z' - 'a') return true;
+        if ((uint)(c - '0') <= '9' - '0') return true;
+        return c switch
+        {
+            '-' or '.' or '_' or '~' => true,
+            '!' or '$' or '&' or '\'' or '(' or ')' or '*' or '+' or ',' or ';' or '=' => true,
+            ':' or '@' => true,
+            _ => false,
+        };
+    }
+
+    private static bool IsHex(char c) =>
+        (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+
+    private static bool IsUpperHex(char c) =>
+        (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F');
+
+    private static char ToUpperHex(char c) =>
+        (c >= 'a' && c <= 'f') ? (char)(c - 32) : c;
+}

--- a/src/Downloader/Request.cs
+++ b/src/Downloader/Request.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using Downloader.Extensions;
 
 namespace Downloader;
 
@@ -42,9 +43,14 @@ public class Request
     /// <param name="config">The configuration for the request.</param>
     public Request(string address, RequestConfiguration config)
     {
-        if (Uri.TryCreate(address, UriKind.Absolute, out Uri uri) == false)
+        // issue #223: percent-encode illegal path characters (e.g. '[', ']',
+        // spaces) before parsing. Without this, Linux' stricter URI parser
+        // rejects otherwise-valid Debrid URLs and downloads fail.
+        string normalized = UrlHelper.EnsurePathEncoded(address);
+
+        if (Uri.TryCreate(normalized, UriKind.Absolute, out Uri uri) == false)
         {
-            uri = new Uri(new Uri("http://localhost"), address);
+            uri = new Uri(new Uri("http://localhost"), normalized);
         }
 
         Address = uri;

--- a/src/Downloader/SocketClient.cs
+++ b/src/Downloader/SocketClient.cs
@@ -140,7 +140,7 @@ public partial class SocketClient : IDisposable
 
         // Add optional headers
         if (!string.IsNullOrWhiteSpace(requestConfig.Referer))
-            client.DefaultRequestHeaders.Referrer = new Uri(requestConfig.Referer);
+            client.DefaultRequestHeaders.Referrer = new Uri(UrlHelper.EnsurePathEncoded(requestConfig.Referer));
 
         if (!string.IsNullOrWhiteSpace(requestConfig.ContentType))
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(requestConfig.ContentType));
@@ -200,7 +200,7 @@ public partial class SocketClient : IDisposable
                      !string.IsNullOrWhiteSpace(redirectedUrl) &&
                      !request.Address.ToString().Equals(redirectedUrl, StringComparison.OrdinalIgnoreCase))
             {
-                request.Address = new Uri(redirectedUrl);
+                request.Address = new Uri(UrlHelper.EnsurePathEncoded(redirectedUrl));
                 await FetchResponseHeaders(request, addRange, cancelToken).ConfigureAwait(false);
             }
             else

--- a/src/Downloader/SocketClient.cs
+++ b/src/Downloader/SocketClient.cs
@@ -140,6 +140,9 @@ public partial class SocketClient : IDisposable
 
         // Add optional headers
         if (!string.IsNullOrWhiteSpace(requestConfig.Referer))
+            // issue #223: normalize before new Uri(). Preserve this wrapper —
+            // removing it re-exposes the bracket/space URL-parse failure on
+            // Linux and also allows control-char injection via Referer.
             client.DefaultRequestHeaders.Referrer = new Uri(UrlHelper.EnsurePathEncoded(requestConfig.Referer));
 
         if (!string.IsNullOrWhiteSpace(requestConfig.ContentType))
@@ -200,6 +203,11 @@ public partial class SocketClient : IDisposable
                      !string.IsNullOrWhiteSpace(redirectedUrl) &&
                      !request.Address.ToString().Equals(redirectedUrl, StringComparison.OrdinalIgnoreCase))
             {
+                // issue #223: normalize server-supplied redirect targets
+                // before new Uri(). Preserve this wrapper — the Location
+                // header is attacker-influenceable and may contain illegal
+                // path characters that would otherwise break Uri parsing on
+                // Linux or enable control-char injection.
                 request.Address = new Uri(UrlHelper.EnsurePathEncoded(redirectedUrl));
                 await FetchResponseHeaders(request, addRange, cancelToken).ConfigureAwait(false);
             }


### PR DESCRIPTION


Closes #223. Originally surfaced via the downstream consumer [rdt-client#962](<https://github.com/rogerfar/rdt-client/pull/962>).

## Problem

`Request.cs` passes the raw address string straight to `Uri.TryCreate`:

```csharp
if (Uri.TryCreate(address, UriKind.Absolute, out Uri uri) == false)
{
    uri = new Uri(new Uri("<http://localhost>"), address);
}
```

Per RFC 3986, square brackets are reserved for IPv6 literals in the **host** component only; `[`, `]`, `{`, `}`, and unencoded spaces are illegal in a path segment and must be percent-encoded. .NET's URI parser is platform-sensitive here:

- **Windows** silently tolerates and auto-encodes these characters, hiding the bug.
- **Linux** (.NET 8 / 9 / 10) is stricter — `TryCreate` either returns `false` (falling through to the `http://localhost` base-URI branch and producing a 404) or yields a `Uri` that `HttpClient` transmits incorrectly.

Real-world triggers are Debrid download links (Real-Debrid, TorBox, AllDebrid) that embed the torrent filename, e.g.:

```
https://real-debrid.com/d/ABCDEF/[SubGroup] Series - 03 [1080p WEB-DL].mkv
```

## Fix

Added `UrlHelper.EnsurePathEncoded(string)` in `src/Downloader/Extensions/UrlHelper.cs`. It:

- **Operates only on the path.** Scheme, userinfo, host (including IPv6 literal brackets like `[::1]`), port, query, and fragment are preserved byte-for-byte.
- **Uses the RFC 3986 `pchar` safe set** — alphanumerics plus `-._~!$&'()*+,;=:@`. Everything else in a segment is percent-encoded as UTF-8. This matches the behavior of Go's `net/url.PathEscape`, Python's `urllib.parse.quote`, and Node's WHATWG URL, so downloads now send the same request line `curl` or a browser would.
- **Is idempotent.** Existing valid `%XX` triplets pass through unchanged (lowercase hex is normalized to uppercase). Safe on already-encoded or partially-encoded input.
- **Decomposes the URL manually** rather than via `Uri`, because `Uri` is exactly what rejects these URLs on Linux.

Wired in at every ingestion point where a server- or user-supplied URL string reaches `new Uri()`:

| File | Line | Site |
|---|---|---|
| `Request.cs` | 49 | Primary entry — every download URL flows here via `AbstractDownloadService.InitialDownloader` |
| `SocketClient.cs` | 203 | HTTP 30x redirect — server-supplied `Location` header |
| `SocketClient.cs` | 143 | `Referer` header |

No public API changes. `UrlHelper` is `internal`.

## Why a helper, not an inline fix?

Three call sites, subtle correctness requirements (idempotency, IPv6-host preservation, pchar set). Centralizing gives one well-tested implementation rather than three near-duplicates.

## Tests

Added `UrlHelperTest.cs` with 26 `[Theory]` cases plus 3 `[Fact]` checks:

- Motivating bug: `[SubGroup] ... [1080p].mkv` → correctly encoded
- Curly braces, unencoded spaces
- Pipe, caret, backtick, double-quote, angle brackets (all illegal in path)
- Query string preserved verbatim even when it contains `[ ]`
- Fragment preserved verbatim
- IPv6 literal host (`[::1]`, `[2001:db8::1]`) left untouched — only path encoded
- Userinfo (`user:pass@host`) preserved
- RFC 3986 sub-delims and `:` `@` preserved in path (not over-encoded)
- `file://` scheme works the same way
- Already-encoded URLs pass through unchanged (idempotency, 6 sample URLs × 2 passes)
- Lowercase hex triplets normalized to uppercase
- Standalone `%` (not followed by two hex digits) encoded to `%25`
- Authority-only URLs with `?` or `#` but no path — unchanged
- Unicode filenames (Arabic) — UTF-8 percent-encoded, round-trips correctly via `Uri.UnescapeDataString`
- `Request` constructor integration: bracketed Debrid URL now yields correct `Host` and `AbsoluteUri`

## Risk / compatibility

- **Windows**: `Uri` previously encoded many of these characters internally anyway; normalizing one step earlier produces identical wire output. No observable regression.
- **Linux**: the failing URLs now succeed. That is the fix.
- **Already-encoded input**: idempotency guarantees no double-encoding.
- **Serialized `DownloadPackage.Urls`**: these come from `req.Address.OriginalString`. After this change that's the normalized form. Resuming a package feeds the URL back through `Request` → idempotent → identical `Address`. No migration needed.
- **Public API**: unchanged.
